### PR TITLE
fixes the fact that 32.3m becomes 32.299.999 (#3)

### DIFF
--- a/src/main/java/com/decimalprices/DecimalPricesKeyListener.java
+++ b/src/main/java/com/decimalprices/DecimalPricesKeyListener.java
@@ -8,6 +8,7 @@ import net.runelite.client.input.KeyListener;
 
 import javax.inject.Inject;
 import java.awt.event.KeyEvent;
+import java.lang.Math;
 
 @Slf4j
 class DecimalPricesKeyListener implements KeyListener {
@@ -56,7 +57,7 @@ class DecimalPricesKeyListener implements KeyListener {
         break;
     }
     // cast the double to an int, truncating anything after the decimal in the process
-    int truncProduct = (int) product;
+    int truncProduct = (int) Math.ceil(product);
     // set the newly converted integer before it is sent to the server
     client.setVarcStrValue(VarClientStr.INPUT_TEXT, String.valueOf(truncProduct));
   }


### PR DESCRIPTION
fixes the fact that 32.3m becomes 32.299.999



https://ideone.com/9dOsOv

https://github.com/rmaes4/decimal-prices/blob/4773c94ec3afb020ca9ffa4efa5ac16462f1b11c/src/main/java/com/decimalprices/DecimalPricesKeyListener.java#L58-L61


I haven't tested every combination, it's possible that some values accidentally become higher as result (i.e. 50.3m becoming 50.31m somehow), I tried with some common testcases and it doesn't seem to be common.